### PR TITLE
Replace player sprite with SVG

### DIFF
--- a/src/assets/sprites/player.svg
+++ b/src/assets/sprites/player.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
+  <rect width="40" height="40" rx="8" ry="8" fill="#e53935" />
+</svg>

--- a/src/game/draw.js
+++ b/src/game/draw.js
@@ -1,6 +1,10 @@
 // src/game/draw.js
 
 import {PLAYER_DIMENSIONS} from './collision';
+import playerSpritePath from '../assets/sprites/player.svg';
+
+const playerImage = new Image();
+playerImage.src = playerSpritePath;
 
 const PLAYER_COLOR = '#e53935';
 const PLATFORM_COLOR = '#6d4c41';
@@ -12,13 +16,23 @@ const PLATFORM_HEIGHT = 20;
  * @param {object} player - Состояние игрока { x, y }.
  */
 function drawPlayer(ctx, player, camera = {x: 0, y: 0}) {
-    ctx.fillStyle = PLAYER_COLOR;
-    ctx.fillRect(
-        player.x - camera.x,
-        player.y - camera.y,
-        PLAYER_DIMENSIONS.width,
-        PLAYER_DIMENSIONS.height
-    );
+    if (playerImage.complete) {
+        ctx.drawImage(
+            playerImage,
+            player.x - camera.x,
+            player.y - camera.y,
+            PLAYER_DIMENSIONS.width,
+            PLAYER_DIMENSIONS.height
+        );
+    } else {
+        ctx.fillStyle = PLAYER_COLOR;
+        ctx.fillRect(
+            player.x - camera.x,
+            player.y - camera.y,
+            PLAYER_DIMENSIONS.width,
+            PLAYER_DIMENSIONS.height
+        );
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a small SVG file for the player sprite
- remove the unused PNG
- update drawing code to render the SVG in the canvas

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea47eb7c08331adc9a992e4329390