### PR TITLE
Implement basic health indicator

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -17,6 +17,7 @@ const GAME_WIDTH = 800;
 const GAME_HEIGHT = 600;
 const WORLD_WIDTH = 2000;
 const COIN_RADIUS = 10;
+const MAX_HEALTH = 5;
 // Высота мира не ограничена снизу, но камера не двигается ниже 0
 
 const Game = () => {
@@ -24,12 +25,14 @@ const Game = () => {
 
         const cameraRef = useRef({x: 0, y: 0});
 
-	const playerRef = useRef({
-		x: 100,
-		y: 100,
-		yVelocity: 0,
-		isGrounded: false,
-	});
+        const playerRef = useRef({
+                x: 100,
+                y: 100,
+                yVelocity: 0,
+                isGrounded: false,
+                health: MAX_HEALTH,
+                maxHealth: MAX_HEALTH,
+        });
 
 	// `playerPosition` state больше не нужен, так как мы не передаем его в дочерний компонент
         const [platforms, setPlatforms] = useState([]);

--- a/src/components/UI/Scoreboard.css
+++ b/src/components/UI/Scoreboard.css
@@ -1,7 +1,7 @@
 .scoreboard {
   position: absolute;
   top: 10px;
-  left: 10px;
+  left: 60px;
   display: flex;
   align-items: center;
   background: rgba(255, 255, 255, 0.7);

--- a/src/game/draw.js
+++ b/src/game/draw.js
@@ -11,6 +11,9 @@ const PLATFORM_COLOR = '#6d4c41';
 const PLATFORM_HEIGHT = 20;
 const COIN_COLOR = '#fdd835';
 const COIN_RADIUS = 10;
+const HEALTH_RADIUS = 20;
+const HEALTH_BG_COLOR = 'rgba(0,0,0,0.3)';
+const HEALTH_COLOR = '#e53935';
 
 /**
  * Рисует игрока на холсте.
@@ -59,6 +62,30 @@ function drawCoin(ctx, coin, camera = {x: 0, y: 0}) {
     ctx.fill();
 }
 
+function drawHealth(ctx, health, maxHealth) {
+    const ratio = Math.max(0, Math.min(health / maxHealth, 1));
+    const x = HEALTH_RADIUS + 10;
+    const y = HEALTH_RADIUS + 10;
+
+    ctx.fillStyle = HEALTH_BG_COLOR;
+    ctx.beginPath();
+    ctx.arc(x, y, HEALTH_RADIUS, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = HEALTH_COLOR;
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.arc(
+        x,
+        y,
+        HEALTH_RADIUS,
+        -Math.PI / 2,
+        -Math.PI / 2 + Math.PI * 2 * ratio
+    );
+    ctx.lineTo(x, y);
+    ctx.fill();
+}
+
 /**
  * Главная функция отрисовки, которая очищает холст и рисует все объекты.
  * @param {CanvasRenderingContext2D} ctx - 2D-контекст холста.
@@ -77,4 +104,8 @@ export function draw(ctx, playerState, platforms, coins = [], camera = {x: 0, y:
     }
 
     drawPlayer(ctx, playerState, camera);
+
+    if (playerState && typeof playerState.health === 'number' && typeof playerState.maxHealth === 'number') {
+        drawHealth(ctx, playerState.health, playerState.maxHealth);
+    }
 }


### PR DESCRIPTION
## Summary
- add a max health constant and initial health to the player
- shift scoreboard to the right to make space for the health indicator
- draw a health circle on the canvas showing current health

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea69932b4833196a9ca14fa9be4f7