### PR TITLE
Add death/reload logic

### DIFF
--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -119,11 +119,16 @@ const Game = () => {
 
 		// Проверяем столкновение с врагами
 		const now = Date.now();
-		const hitEnemy = checkEnemyCollision(playerRef.current, enemies);
-		if (hitEnemy && now - playerRef.current.lastHit > DAMAGE_COOLDOWN) {
-			playerRef.current.health = Math.max(0, playerRef.current.health - 1);
-			playerRef.current.lastHit = now;
-		}
+                const hitEnemy = checkEnemyCollision(playerRef.current, enemies);
+                if (hitEnemy && now - playerRef.current.lastHit > DAMAGE_COOLDOWN) {
+                        playerRef.current.health = Math.max(0, playerRef.current.health - 1);
+                        playerRef.current.lastHit = now;
+                }
+
+                if (playerRef.current.health <= 0) {
+                        window.location.reload();
+                        return;
+                }
 
 		// --- Новая логика отрисовки ---
 		const canvas = canvasRef.current;


### PR DESCRIPTION
## Summary
- restart the game when the player's health reaches zero

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec6f140ec8331bc3da2a80cee8801